### PR TITLE
split requirements.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ENV PYTHONUNBUFFERED 1
 ENV USE_POSTGRESQL 1
 RUN mkdir /code
 WORKDIR /code
-COPY requirements.txt /code/
-RUN pip install -r requirements.txt
+COPY requirements.txt requirements_dev.txt /code/
+RUN pip install -r requirements_dev.txt
 RUN pip install psycopg2-binary==2.7.7
 COPY . /code/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,21 +4,13 @@
 // This script is assuming that you're using a multi-branch project but the majority directly translates to a regular pipeline project.
 
 node {
-
-	sh 'cd $WORKSPACE && rm -rf venv && virtualenv -p python3 venv'
-
         checkout scm
 
         sh '''
-            cd $WORKSPACE
-            source venv/bin/activate
-            pip3 install -r requirements_dev.txt
-            deactivate
-           '''
-
-        sh '''
 cd $WORKSPACE
+rm -rf venv && virtualenv -p python3 venv
 source venv/bin/activate
+pip3 install -r requirements_dev.txt
 cat <<ENDOFFILE > my.cnf
 [client]
 database = pytition

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ node {
         sh '''
             cd $WORKSPACE
             source venv/bin/activate
-            pip3 install -r requirements.txt 
+            pip3 install -r requirements_dev.txt
             deactivate
            '''
 

--- a/dev/dev_setup.sh
+++ b/dev/dev_setup.sh
@@ -27,7 +27,7 @@ source venv/bin/activate
 
 echo "Installing Pytition Python runtime dependencies"
 
-pip3 install -r requirements.txt
+pip3 install -r requirements_dev.txt
 
 echo "Install MariaDB server? (y/n)"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,4 @@ mysqlclient==1.3.13
 django-widget-tweaks==1.4.3
 beautifulsoup4~=4.6.3
 django-formtools==2.1
-coverage==4.5.2
 bcrypt

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+coverage==4.5.2


### PR DESCRIPTION
split the requirements in 2 files.

This makes it possible to not install dev dependencies in production (like coverage)

The dev requirements are still installed in the docker since it seems the dockers are only used for dev purposes

fixes #72