### PR TITLE
fix - Display error alert when remove user from orga failed

### DIFF
--- a/pytition/locale/fr_FR/LC_MESSAGES/django.po
+++ b/pytition/locale/fr_FR/LC_MESSAGES/django.po
@@ -1054,7 +1054,7 @@ msgstr ""
 msgid "Remove this member from the organization."
 msgstr "Enlever cet utilisateur de l\\'organisation'."
 
-#: pytition/petition/template/orga.js:82
+#: pytition/petition/templates/petition/org_member_list.html:39
 msgid "Unable to remove this member from the organization."
 msgstr "Impossible d'enlever cet utilisateur de l'organisation."
 

--- a/pytition/locale/fr_FR/LC_MESSAGES/django.po
+++ b/pytition/locale/fr_FR/LC_MESSAGES/django.po
@@ -1054,6 +1054,10 @@ msgstr ""
 msgid "Remove this member from the organization."
 msgstr "Enlever cet utilisateur de l\\'organisation'."
 
+#: pytition/petition/template/orga.js:82
+msgid "Unable to remove this member from the organization."
+msgstr "Impossible d'enlever cet utilisateur de l'organisation."
+
 #: pytition/petition/templates/petition/org_profile.html:5
 #, python-format
 msgid ""

--- a/pytition/petition/templates/petition/org_member_list.html
+++ b/pytition/petition/templates/petition/org_member_list.html
@@ -31,3 +31,18 @@
     {% endfor %}
   </ul>
 </div>
+
+<div class="modal fade" id="member_delete_error_modal">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-body">
+        {% trans "Unable to remove this member from the organization." %}
+      </div>
+
+      <div class="modal-footer">
+        <button type="button" class="btn btn-info" data-dismiss="modal">OK</button>
+      </div>
+
+    </div>
+  </div>
+</div>

--- a/pytition/petition/templates/petition/orga.js
+++ b/pytition/petition/templates/petition/orga.js
@@ -78,6 +78,8 @@ $(function () {
             window.location = "{% url "user_dashboard" %}";
         else
             window.location = window.location.href;
+       }).fail((xhr, status, error) => {
+            alert("{% trans 'Unable to remove this member from the organization.' %}");
        });
     });
 });

--- a/pytition/petition/templates/petition/orga.js
+++ b/pytition/petition/templates/petition/orga.js
@@ -79,7 +79,7 @@ $(function () {
         else
             window.location = window.location.href;
        }).fail((xhr, status, error) => {
-            alert("{% trans 'Unable to remove this member from the organization.' %}");
+            $('#member_delete_error_modal').modal('show')
        });
     });
 });


### PR DESCRIPTION
## Object
* Fixes #160 .
* As the back end doesn't send a message explaining the HTTP 403 error, it just use js alert to warn the user.
* I didn't find any way already implemented to handle error messages display in the front, that is why I decided to use `alert`.
* [x] Translation
* [ ] Translation compilation
* Feel free to comment if you have a better solution.

## Test
* Tested with `docker-compose` on Mac OS.