### PR TITLE
feat - Add options display for prepopulate script prompt

### DIFF
--- a/dev/initialize.sh
+++ b/dev/initialize.sh
@@ -10,7 +10,7 @@ cd pytition && python3 ./manage.py createsuperuser && cd -
 
 echo "Done"
 
-echo "Do you want to pre-populate the database with some users, organizations and petitions?"
+echo "Do you want to pre-populate the database with some users, organizations and petitions? (y/N)"
 
 read prepopulate
 


### PR DESCRIPTION
## Object
* Show available options and default option for answering prepopulation prompt in `dev/initialize.sh`.
* Doesn't change script behaviour.

## Test
* Tested with `docker-compose` on Mac OS.