### PR TITLE
On small screen form is too small

### DIFF
--- a/pytition/petition/templates/registration/login.html
+++ b/pytition/petition/templates/registration/login.html
@@ -4,7 +4,7 @@
 {% block main_content %}
 <div class="container">
   <div class="row">
-    <div class="offset-3 col-6 text-center">
+    <div class="col-12 offset-sm-1 col-sm-10 offset-md-2 col-md-8 text-center">
       <h1 class="h3 mb-5 font-weight-normal">{% trans 'Please sign in' %}</h1>
       {% if form.errors %}
         <div class="alert alert-danger alert-dismissible fade show" role="alert">
@@ -23,7 +23,7 @@
       {% endif %}
 
       <div class="row">
-        <div class="offset-3 col-6">
+        <div class="col-12 offset-sm-3 col-sm-6">
       <form method="post" action="{% url 'login' %}">
         {% csrf_token %}
         <input type="text" name="username" id="{{ form.username.auto_id }}" class="form-control" placeholder="Username" required autofocus>


### PR DESCRIPTION
Hello,

A small pull request to concern the registration form. On mobile, fields are too small. See pictures :

intial screen for existant and others pictures for differents sizes after modification.

A great tool Pytition.

Thanks.

----

*on mobile screen after modification*

![version mobile](https://user-images.githubusercontent.com/20518176/71805526-c5b51d80-3066-11ea-8983-595e42e0aadb.png)

*on tablet screen after modification*

![version_sm](https://user-images.githubusercontent.com/20518176/71805527-c5b51d80-3066-11ea-9570-6ed6c869612d.png)

*on large screen after modification*

![version_md](https://user-images.githubusercontent.com/20518176/71805529-c64db400-3066-11ea-92f2-00d80a0b5d46.png)

*Inittial*

![initial_screen](https://user-images.githubusercontent.com/20518176/71805530-c64db400-3066-11ea-923d-e0cede91d555.png)
