### PR TITLE
Fix #197 clickable img in petition creation 

### DIFF
--- a/pytition/petition/templates/petition/new_petition_step3.html
+++ b/pytition/petition/templates/petition/new_petition_step3.html
@@ -14,11 +14,9 @@
   <input type="hidden" name="redirect" id="redirectField" value="0">
     <div class="col-xl-4 col-lg-6 col-sm-12 col-12 mx-auto text-center sb-preview">
       <div class="card h-100 align-content-center">
-        <a href="#" class="sb-preview-img">
-          <img class="card-img-top img-fluid img-thumbnail" src="{% static "img/petition_icon.svg" %}">
-        </a>
+        <img class="card-img-top img-fluid img-thumbnail" src="{% static "img/petition_icon.svg" %}">
         <div class="card-body d-flex flex-column">
-          <h4 class="card-title"> {{ title }}</h4>
+          <h4 class="card-title">{{ title }}</h4>
           <p class="card-text">{{ message|striptags|truncatechars:225 }}</p>
         </div>
         <div class="card-footer mt-auto">


### PR DESCRIPTION
Hello there!

Simple change to remove the clickable image at the end of petition creation (fixes #197)

I deleted the `a` tag altogether because the class `sb-preview-img` did not seem to have any effect.