### PR TITLE
Fix #194 Add language selection form

### DIFF
--- a/pytition/petition/templates/layouts/nav.html
+++ b/pytition/petition/templates/layouts/nav.html
@@ -9,7 +9,21 @@
         Menu <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarResponsive">
-      <form class="form-inline my-2 my-lg-0 ml-auto" action="{% url 'search' %}" method="GET">
+      <form class="form-inline my-2 my-lg-0 ml-auto" action="{% url 'set_language' %}" method="post">
+        {% csrf_token %}
+        <input name="next" type="hidden" value="{{ redirect_to }}">
+        <select class="custom-select custom-select-sm" name="language" onchange='if(this.value !=  "{{ LANGUAGE_CODE }}") { this.form.submit(); }'>
+          {% get_current_language as LANGUAGE_CODE %}
+          {% get_available_languages as LANGUAGES %}
+          {% get_language_info_list for LANGUAGES as languages %}
+          {% for language in languages %}
+            <option value="{{ language.code }}" {% if language.code == LANGUAGE_CODE %}selected{% endif %}>
+              {{ language.code }}
+            </option>
+          {% endfor %}
+        </select>
+      </form>
+      <form class="form-inline my-2 my-lg-0 ml-0 ml-sm-3" action="{% url 'search' %}" method="GET">
         <div class="input-group input-group-sm">
           <input type="text" class="form-control" placeholder="{% trans "Search for petition" %}" name="q" value="{{ q }}">
           <div class="input-group-append">

--- a/pytition/petition/templates/layouts/nav_dashboard.html
+++ b/pytition/petition/templates/layouts/nav_dashboard.html
@@ -14,7 +14,21 @@
         Menu <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarResponsive">
-      <form class="form-inline my-2 my-lg-0 ml-auto" action="{% url 'search' %}" method="GET">
+      <form class="form-inline my-2 my-lg-0 ml-auto" action="{% url 'set_language' %}" method="post">
+        {% csrf_token %}
+        <input name="next" type="hidden" value="{{ redirect_to }}">
+        <select class="custom-select custom-select-sm" name="language" onchange='if(this.value !=  "{{ LANGUAGE_CODE }}") { this.form.submit(); }'>
+          {% get_current_language as LANGUAGE_CODE %}
+          {% get_available_languages as LANGUAGES %}
+          {% get_language_info_list for LANGUAGES as languages %}
+          {% for language in languages %}
+            <option value="{{ language.code }}" {% if language.code == LANGUAGE_CODE %}selected{% endif %}>
+              {{ language.code }}
+            </option>
+          {% endfor %}
+        </select>
+      </form>
+      <form class="form-inline my-2 my-lg-0 ml-0 ml-sm-3" action="{% url 'search' %}" method="GET">
         <div class="input-group input-group-sm">
           <input type="text" class="form-control" placeholder="{% trans "Search for petition" %}" name="q" value="{{ q }}">
           <div class="input-group-append">

--- a/pytition/pytition/settings/base.py
+++ b/pytition/pytition/settings/base.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 """
 
 import os
+import django.conf.locale
 from django.contrib.messages import constants as messages
 from django.urls import reverse_lazy
 from django.conf import global_settings
@@ -222,7 +223,20 @@ INDEX_PAGE = "HOME"
 SIGNATURE_THROTTLE = 5 # 5 signatures from same IP allowed
 SIGNATURE_THROTTLE_TIMING = 60*60*24 # in a 1 day time frame
 
-LANGUAGES = global_settings.LANGUAGES + [('oc', gettext_lazy('Occitan'))]
+LANGUAGES = [
+    ('en', 'English'),
+    ('fr', 'Français'),
+    ('oc', 'Occitan'),
+]
+
+EXTRA_LANG_INFO = {
+    'oc': {
+        'code': 'oc',
+        'name': 'Occitan',
+    },
+}
+LANG_INFO = dict(django.conf.locale.LANG_INFO, **EXTRA_LANG_INFO)
+django.conf.locale.LANG_INFO = LANG_INFO
 
 if DEFAULT_INDEX_THUMBNAIL == "":
     print("Please set a default index thumbnail or your index page will not be very beautiful")


### PR DESCRIPTION
Fixes #194

I needed to make a couple of changes in the base settings file because Occitan is not officially supported by Django.

WIP as the following points need to be discussed:

**1) the UI rendering**

I made it look this way for now, but happy to change if you have a suggestion:
![image](https://user-images.githubusercontent.com/6069449/75091753-13330e80-5571-11ea-9896-8c5b0e2d22e1.png)

**2) the list of languages**
Currently it gets all the languages even when the translation is incomplete / missing, because of this line `LANGUAGES = global_settings.LANGUAGES`. I would advise to have a list of languages set in the base settings file