### PR TITLE
Fix #166 add petition title in "show signatories" page

### DIFF
--- a/pytition/petition/templates/petition/signature_data.html
+++ b/pytition/petition/templates/petition/signature_data.html
@@ -8,6 +8,11 @@
         </div>
     </div>
     <div class="row">
+        <div class="col d-flex justify-content-center">
+            <h4><i>{{ petition.title }}</i></h4>
+        </div>
+    </div>
+    <div class="row">
         <form method="POST" id="signatureForm">
         {% csrf_token %}
         <div class="col">


### PR DESCRIPTION
Fix #166 

Decided to use `h4` to try to make it fit in one line even if the petition title is relatively long