### PR TITLE
Couple of best practices for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM python:3
+FROM python:3.8
 ENV PYTHONUNBUFFERED 1
 ENV USE_POSTGRESQL 1
 
-RUN apt-get -y update
-RUN apt-get install -y gettext
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y gettext && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /code
 WORKDIR /code


### PR DESCRIPTION
Minor tweaks to follow [Dockerfile best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) a bit closer.

- Pin version of the python image to prevent failures due to unanticipated changes
- Only one layer for the installation of packages (gettext)
- Apt cache cleaned up to reduce the image size