### PR TITLE
Add Maildev as Fake SMTP for dev

### DIFF
--- a/dev/generate_docker_config.sh
+++ b/dev/generate_docker_config.sh
@@ -7,3 +7,5 @@ echo "SECRET_KEY = \"${SECRET_KEY}\"" >> /config/docker_config.py
 echo "STATIC_ROOT = \"/static/\"" >> /config/docker_config.py
 echo "DEBUG = True" >> /config/docker_config.py
 echo "ALLOWED_HOSTS.append('0.0.0.0')" >> /config/docker_config.py
+echo "EMAIL_HOST = 'smtp'" >> /config/docker_config.py
+echo "EMAIL_PORT = 2525" >> /config/docker_config.py

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -293,6 +293,9 @@ Last command before being able to click on the "http://0.0.0.0:8000/" link that 
 
   $ docker-compose exec web ./dev/initialize.sh
 
-Aaaand that's it! You can now just click on the "http://0.0.0.0:8000/" link!
+Aaaand that's it! You can now just click on the links:
+
+- http://0.0.0.0:8000/ for the Pytition interface
+- http://0.0.0.0:8080/ for the mail server web interface
 
 Next time, just run ``$ docker-compose up --build``

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,12 @@ services:
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
+  smtp:
+    image: maildev/maildev:1.1.0
+    command: bin/maildev --web 8080 --smtp 2525 --verbose
+    ports:
+      - "8080:8080"
+      - "2525:2525"
   web:
     environment:
       - DJANGO_SETTINGS_MODULE=config.docker_config
@@ -18,3 +24,4 @@ services:
       - "8000:8000"
     depends_on:
       - db
+      - smtp


### PR DESCRIPTION
Fixes https://github.com/pytition/Pytition/issues/231
Adds Maildev in docker-compose to allow people to play with features requiring SMTP server up

Notes:
* I used the default ports (25 for smtp, 8080 for web interface), that can easily be changed if needed.
* I used the script generate_docker_config.sh for the settings, I'll let you confirm whether this was a good idea :)
* I did not write any documentation about this