### PR TITLE
Only show "Create a petition" if logged in

### DIFF
--- a/pytition/petition/templates/petition/index.html
+++ b/pytition/petition/templates/petition/index.html
@@ -10,10 +10,12 @@
   <div class="container">
     <h1 class="jumbotron-heading">{% trans "Welcome to Pytition"%}</h1>
     <p class="lead text-muted">{% trans "Make things change!" %}</p>
-  {% if settings.SHOW_DEMO_TEXT %}
-    {% include 'petition/demo_text.html' %}
-  {% endif %}
-    <p><a href="{% url 'user_petition_wizard' %}" class="btn btn-primary">{% trans "Create a petition" %}</a></p>
+    {% if settings.SHOW_DEMO_TEXT %}
+      {% include 'petition/demo_text.html' %}
+    {% endif %}
+    {% if user.is_authenticated %}
+      <p><a href="{% url 'user_petition_wizard' %}" class="btn btn-primary">{% trans "Create a petition" %}</a></p>
+    {% endif %}
   </div>
 </section>
 <section class="petition-list bg-light">


### PR DESCRIPTION
Very minor update: only show the "Create a petition" button on home page if logged in
I used the occasion to correct the indentation on the lines above to be more consistent with the rest of the code.

Fixes https://github.com/pytition/Pytition/issues/241