### PR TITLE
Fixes #195 add chronological sorting to home page, user/org profile page

### DIFF
--- a/pytition/petition/templates/petition/generic_petition_list.html
+++ b/pytition/petition/templates/petition/generic_petition_list.html
@@ -62,7 +62,7 @@
   <div>
     <ul class="pagination justify-content-center">
       {% if petitions.has_previous %}
-        <li class="page-item"><a class="page-link" href="?page={{ petitions.previous_page_number }}">&laquo;</a></li>
+        <li class="page-item"><a class="page-link" href="?page={{ petitions.previous_page_number }}&sort={{ sort }}">&laquo;</a></li>
       {% else %}
         <li class="page-item disabled"><span class="page-link">&laquo;</span></li>
       {% endif %}
@@ -70,11 +70,11 @@
         {% if petitions.number == i %}
           <li class="page-item active"><span class="page-link">{{ i }} <span class="sr-only">(current)</span></span></li>
         {% else %}
-          <li class="page-item"><a class="page-link" href="?page={{ i }}">{{ i }}</a></li>
+          <li class="page-item"><a class="page-link" href="?page={{ i }}&sort={{ sort }}">{{ i }}</a></li>
         {% endif %}
       {% endfor %}
       {% if petitions.has_next %}
-        <li class="page-item"><a class="page-link" href="?page={{ petitions.next_page_number }}">&raquo;</a></li>
+        <li class="page-item"><a class="page-link" href="?page={{ petitions.next_page_number }}&sort={{ sort }}">&raquo;</a></li>
       {% else %}
         <li class="page-item disabled"><span class="page-link">&raquo;</span></li>
       {% endif %}

--- a/pytition/petition/templates/petition/index.html
+++ b/pytition/petition/templates/petition/index.html
@@ -24,9 +24,9 @@
     <div class="d-flex justify-content-end">
       <div class="btn-group" role="group" aria-label="sort-buttons">
           <a class="btn {% if sort == 'desc' %} btn-secondary {% else %} btn-outline-secondary {% endif %}"
-              href="{% url "index" %}?sort=desc#petition-list-id" role="button">Last Created</a>
+              href="{% url "index" %}?sort=desc#petition-list-id" role="button">{% trans "Last Created" %}</a>
           <a class="btn {% if sort == 'asc' %} btn-secondary {% else %} btn-outline-secondary {% endif %}"
-              href="{% url "index" %}?sort=asc#petition-list-id" role="button">First Created</a>
+              href="{% url "index" %}?sort=asc#petition-list-id" role="button">{% trans "First Created" %}</a>
       </div>
     </div>
     {% include 'petition/generic_petition_list.html' with petitions=petitions sort=sort %}

--- a/pytition/petition/templates/petition/index.html
+++ b/pytition/petition/templates/petition/index.html
@@ -18,10 +18,18 @@
     {% endif %}
   </div>
 </section>
-<section class="petition-list bg-light">
+<section id="petition-list-id" class="petition-list bg-light">
   <div class="text-center container">
     <h2>{% trans "View latest petitions" %}</h2>
-    {% include 'petition/generic_petition_list.html' with petitions=petitions %}
+    <div class="d-flex justify-content-end">
+      <div class="btn-group" role="group" aria-label="sort-buttons">
+          <a class="btn {% if sort == 'desc' %} btn-secondary {% else %} btn-outline-secondary {% endif %}"
+              href="{% url "index" %}?sort=desc#petition-list-id" role="button">Last Created</a>
+          <a class="btn {% if sort == 'asc' %} btn-secondary {% else %} btn-outline-secondary {% endif %}"
+              href="{% url "index" %}?sort=asc#petition-list-id" role="button">First Created</a>
+      </div>
+    </div>
+    {% include 'petition/generic_petition_list.html' with petitions=petitions sort=sort %}
   </div>
 </section>
 

--- a/pytition/petition/templates/petition/org_profile.html
+++ b/pytition/petition/templates/petition/org_profile.html
@@ -18,6 +18,14 @@
     <div class="row">
         <h2>{{ org.name }} </h2>
     </div>
-    {% include 'petition/generic_petition_list.html' with petitions=petitions %}
+    <div class="d-flex justify-content-end">
+        <div class="btn-group" role="group" aria-label="sort-buttons">
+            <a class="btn {% if sort == 'desc' %} btn-secondary {% else %} btn-outline-secondary {% endif %}"
+                href="{% url "org_profile" org.slugname %}?sort=desc" role="button">Last Created</a>
+            <a class="btn {% if sort == 'asc' %} btn-secondary {% else %} btn-outline-secondary {% endif %}"
+                href="{% url "org_profile" org.slugname %}?sort=asc" role="button">First Created</a>
+        </div>
+    </div>
+    {% include 'petition/generic_petition_list.html' with petitions=petitions sort=sort %}
 </div>
 {% endblock main_content %}

--- a/pytition/petition/templates/petition/org_profile.html
+++ b/pytition/petition/templates/petition/org_profile.html
@@ -21,9 +21,9 @@
     <div class="d-flex justify-content-end">
         <div class="btn-group" role="group" aria-label="sort-buttons">
             <a class="btn {% if sort == 'desc' %} btn-secondary {% else %} btn-outline-secondary {% endif %}"
-                href="{% url "org_profile" org.slugname %}?sort=desc" role="button">Last Created</a>
+                href="{% url "org_profile" org.slugname %}?sort=desc" role="button">{% trans "Last Created" %}</a>
             <a class="btn {% if sort == 'asc' %} btn-secondary {% else %} btn-outline-secondary {% endif %}"
-                href="{% url "org_profile" org.slugname %}?sort=asc" role="button">First Created</a>
+                href="{% url "org_profile" org.slugname %}?sort=asc" role="button">{% trans "First Created" %}</a>
         </div>
     </div>
     {% include 'petition/generic_petition_list.html' with petitions=petitions sort=sort %}

--- a/pytition/petition/templates/petition/user_profile.html
+++ b/pytition/petition/templates/petition/user_profile.html
@@ -18,9 +18,17 @@
     <div class="row">
         <h2>{{user.name }} </h2>
     </div>
+    <div class="d-flex justify-content-end">
+        <div class="btn-group" role="group" aria-label="sort-buttons">
+            <a class="btn {% if sort == 'desc' %} btn-secondary {% else %} btn-outline-secondary {% endif %}"
+                href="{% url "user_profile" user.username %}?sort=desc" role="button">Last Created</a>
+            <a class="btn {% if sort == 'asc' %} btn-secondary {% else %} btn-outline-secondary {% endif %}"
+                href="{% url "user_profile" user.username %}?sort=asc" role="button">First Created</a>
+        </div>
+    </div>
     {% blocktrans asvar no_petitions_text %}
         This user has not created any petition yet
     {% endblocktrans %}
-    {% include 'petition/generic_petition_list.html' with petitions=petitions no_petitions_text=no_petitions_text %}
+    {% include 'petition/generic_petition_list.html' with petitions=petitions no_petitions_text=no_petitions_text sort=sort %}
 </div>
 {% endblock main_content %}

--- a/pytition/petition/templates/petition/user_profile.html
+++ b/pytition/petition/templates/petition/user_profile.html
@@ -21,9 +21,9 @@
     <div class="d-flex justify-content-end">
         <div class="btn-group" role="group" aria-label="sort-buttons">
             <a class="btn {% if sort == 'desc' %} btn-secondary {% else %} btn-outline-secondary {% endif %}"
-                href="{% url "user_profile" user.username %}?sort=desc" role="button">Last Created</a>
+                href="{% url "user_profile" user.username %}?sort=desc" role="button">{% trans "Last Created" %}</a>
             <a class="btn {% if sort == 'asc' %} btn-secondary {% else %} btn-outline-secondary {% endif %}"
-                href="{% url "user_profile" user.username %}?sort=asc" role="button">First Created</a>
+                href="{% url "user_profile" user.username %}?sort=asc" role="button">{% trans "First Created" %}</a>
         </div>
     </div>
     {% blocktrans asvar no_petitions_text %}

--- a/pytition/petition/views.py
+++ b/pytition/petition/views.py
@@ -75,7 +75,9 @@ def index(request):
             user = get_session_user(request)
         else:
             user = request.user
-        all_petitions = Petition.objects.filter(published=True).order_by('-id')
+        sort = request.GET.get('sort', 'desc')
+        creation_date = '-creation_date' if sort == 'desc' else 'creation_date'
+        all_petitions = Petition.objects.filter(published=True).order_by(creation_date)
         paginator = Paginator(all_petitions, settings.PAGINATOR_COUNT)
         page = request.GET.get('page')
         petitions = paginator.get_page(page)
@@ -83,7 +85,8 @@ def index(request):
         return render(request, 'petition/index.html',
                 {
                     'user': user,
-                    'petitions': petitions
+                    'petitions': petitions,
+                    'sort': sort
                 }
         )
 
@@ -336,8 +339,9 @@ def user_profile(request, user_name):
         user = PytitionUser.objects.get(user__username=user_name)
     except PytitionUser.DoesNotExist:
         raise Http404(_("not found"))
-
-    petitions = user.petition_set.filter(published=True).order_by('-id')
+    sort = request.GET.get('sort', 'desc')
+    creation_date = '-creation_date' if sort == 'desc' else 'creation_date'
+    petitions = user.petition_set.filter(published=True).order_by(creation_date)
     paginator = Paginator(petitions, settings.PAGINATOR_COUNT)
     page = request.GET.get('page')
     petitions = paginator.get_page(page)
@@ -345,7 +349,7 @@ def user_profile(request, user_name):
     return render(
         request,
         'petition/user_profile.html',
-        {'user': user, 'petitions': petitions}
+        {'user': user, 'petitions': petitions, 'sort': sort }
     )
 
 
@@ -386,13 +390,16 @@ def org_profile(request, orgslugname):
     except Organization.DoesNotExist:
         raise Http404(_("not found"))
 
-    petitions = org.petition_set.filter(published=True).order_by('-id')
+    sort = request.GET.get('sort', 'desc')
+    creation_date = '-creation_date' if sort == 'desc' else 'creation_date'
+    petitions = org.petition_set.filter(published=True).order_by(creation_date)
     paginator = Paginator(petitions, settings.PAGINATOR_COUNT)
     page = request.GET.get('page')
     petitions = paginator.get_page(page)
 
     ctx = {'org': org,
-           'petitions': petitions}
+           'petitions': petitions,
+           'sort': sort}
 
     # if a user is logged-in, put it in the context, it will feed the navbar dropdown
     if user is not None:


### PR DESCRIPTION
Fixes #195

- This pull request adds chronological sorting to the Home page, User profile page, organization page.
- "creation_date" is used for sorting
- I initially planned to use drop-down for sorting. But I chose "segmented button" because I think it looks nicer on UI and the code will be simpler.

I am happy to fix or refactor if there are any problems with code, UI, etc.

**Orgnization Profile Page**
![Screen Shot 2020-10-17 at 8 53 47 PM](https://user-images.githubusercontent.com/4319619/96337640-2758ec80-10bb-11eb-986f-59588a6f2f59.png)

**User Profile Page**
![Screen Shot 2020-10-17 at 8 54 09 PM](https://user-images.githubusercontent.com/4319619/96337646-2b850a00-10bb-11eb-9a9e-20d342ec9828.png)

**Home Page**
![Screen Shot 2020-10-17 at 8 54 45 PM](https://user-images.githubusercontent.com/4319619/96337649-2de76400-10bb-11eb-8439-fbe504d1e883.png)
