### PR TITLE
feat: add django-maintenance-mode requirement

### DIFF
--- a/pytition/petition/templates/503.html
+++ b/pytition/petition/templates/503.html
@@ -1,0 +1,1 @@
+En maintenance.

--- a/pytition/pytition/settings/base.py
+++ b/pytition/pytition/settings/base.py
@@ -25,6 +25,7 @@ ALLOWED_HOSTS = ['0.0.0.0', '127.0.0.1', 'localhost', '[::1]']
 # Application definition
 
 INSTALLED_APPS = [
+    'maintenance_mode',
     'tinymce',
     'colorfield',
     'petition.apps.PetitionConfig',
@@ -47,6 +48,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'maintenance_mode.middleware.MaintenanceModeMiddleware',
 ]
 
 PASSWORD_HASHERS = [
@@ -73,6 +75,7 @@ TEMPLATES = [
                 'django.template.context_processors.i18n',
                 'django.template.context_processors.request',
                 'django.contrib.messages.context_processors.messages',
+                'maintenance_mode.context_processors.maintenance_mode',
 
             ],
         },
@@ -267,3 +270,5 @@ RESTRICT_ORG_CREATION = False
 
 #:| Default address for 'Reply to' field in mail sent on account creation
 DEFAULT_NOREPLY_MAIL = "noreply@domain.tld"
+
+MAINTENANCE_MODE_IGNORE_ADMIN_SITE = True

--- a/pytition/pytition/urls.py
+++ b/pytition/pytition/urls.py
@@ -25,4 +25,5 @@ urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'^tinymce/', include('tinymce.urls')),
     url(r'^i18n/', include('django.conf.urls.i18n')),
+    url(r'^maintenance-mode/', include('maintenance_mode.urls')),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Django~=2.2.0
 django-colorfield==0.1.15
 django-tinymce==2.8.0
 django-mailer==1.2.6
+django-maintenance-mode
 requests~=2.20.0
 mysqlclient==1.3.13
 django-widget-tweaks==1.4.3


### PR DESCRIPTION
With django-maintenance-mode, the site can be stopped before an upgrade or a database migration. The goal is to maintain the coherence of the database during the upgrade process.