### PR TITLE
fix: always show password reset link on login template

### DIFF
--- a/pytition/petition/templates/registration/login.html
+++ b/pytition/petition/templates/registration/login.html
@@ -33,8 +33,8 @@
       </form>
       {% if settings.ALLOW_REGISTER %}
       <div class="mt-3"> {% trans "No account?" %} <a href="{% url "register" %}">{% trans "Register!" %}</a></div>
-        <p><a href="{% url "password_reset" %}">{% trans "I forgot my password!" %}</a></p>
       {% endif %}
+        <div class="mt-3"><a href="{% url "password_reset" %}">{% trans "I forgot my password!" %}</a></div>
       </div>
         </div>
     </div>


### PR DESCRIPTION
When register option is false, the password reset link desepear. This fix it.