### PR TITLE
fix: print membre.username if membre.get_full_name is empty

### DIFF
--- a/pytition/petition/templates/petition/org_member_list.html
+++ b/pytition/petition/templates/petition/org_member_list.html
@@ -4,7 +4,7 @@
   <ul class="dashboard-org-list">
   {% for member in org.members.all %}
     <li class="d-flex align-items-center justify-content-between">
-      <a class="text-dark" href="{% url "user_profile" member.username %}">{{ member.get_full_name }}</a>
+      <a class="text-dark" href="{% url "user_profile" member.username %}">{% firstof member.get_full_name member.username %}</a>
       <div data-member="{{ member.username }}">
         <a href="{% url "org_edit_user_perms" org.slugname member.username %}"
           {% if not user_permissions.can_modify_permissions %}


### PR DESCRIPTION
When first and last name are empty, nothing is print in the organisation owner/member part
This fixes it.