### PR TITLE
pdm docker: fix venv path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.8
 ENV PYTHONUNBUFFERED 1
 ENV USE_POSTGRESQL 1
+ENV PDM_PYTHON /venv/.venv/bin/python
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y gettext && \
@@ -16,7 +17,6 @@ WORKDIR /code
 COPY pyproject.toml pdm.lock /venv/
 RUN cd /venv && pdm sync
 RUN cd /venv && pdm add psycopg[binary]==3.1.8
-RUN pdm use -f /venv/.venv
 COPY . /code/
 COPY pytition/pytition/settings/config_example.py /config/docker_config.py
 RUN touch /config/__init__.py

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -311,7 +311,7 @@ Last command before being able to click on the "http://0.0.0.0:8000/" link that 
 
 .. code-block:: bash
 
-  $ docker-compose exec web ./dev/initialize.sh
+  $ docker-compose exec web pdm run ./dev/initialize.sh
 
 Aaaand that's it! You can now just click on the links:
 


### PR DESCRIPTION
I don’t know pdm but it seems it needs the correct venv path in `PDM_PYTHON` env var, or in `.pdm-python` file which is apparently generated by `pdm use -f /venv/.venv`. Also, subsequent python commands seems to need to be run with `pdm run …`

To be confirmed but for me, it fix #328 